### PR TITLE
Added history inside json response

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-async-errors": "^3.1.1",
+    "moment": "^2.24.0",
     "mongoose": "^5.9.4",
     "request": "^2.88.2",
     "youch": "^2.0.10"

--- a/src/app.js
+++ b/src/app.js
@@ -7,31 +7,31 @@ const Youch = require("youch");
 const cors = require("cors");
 
 class App {
-  constructor() {
-    this.server = express();
+    constructor() {
+        this.server = express();
 
-    this.middlewares();
-    this.routes();
-  }
+        this.middlewares();
+        this.routes();
+    }
 
-  middlewares() {
-    this.server.use(cors());
-    this.server.use(
-      express.urlencoded({
-        extended: true
-      })
-    );
-    this.server.use(express.json());
-  }
+    middlewares() {
+        this.server.use(cors());
+        this.server.use(
+            express.urlencoded({
+                extended: true
+            })
+        );
+        this.server.use(express.json());
+    }
 
-  routes() {
-    this.server.use(routes);
-    this.server.use(async (err, req, res, next) => {
-      const errors = await new Youch(err, req).toJSON();
-      console.log(errors);
-      return res.status(500).json({ message: error });
-    });
-  }
+    routes() {
+        this.server.use(routes);
+        this.server.use(async(err, req, res, next) => {
+            const errors = await new Youch(err, req).toJSON();
+            console.log(errors);
+            return res.status(500).json({ message: errors });
+        });
+    }
 }
 
 module.exports = new App().server;

--- a/src/app/models/mds.js
+++ b/src/app/models/mds.js
@@ -1,9 +1,10 @@
 var mongoose = require("mongoose");
 
 var mdsSchema = new mongoose.Schema({
-  world: mongoose.Schema.Types.Mixed,
-  brazil: mongoose.Schema.Types.Mixed,
-  updated_at: Date
+    world: mongoose.Schema.Types.Mixed,
+    brazil: mongoose.Schema.Types.Mixed,
+    history: mongoose.Schema.Types.Mixed,
+    updated_at: Date
 });
 
 module.exports = mongoose.model("MDS", mdsSchema);

--- a/src/helpers/mds.js
+++ b/src/helpers/mds.js
@@ -1,31 +1,56 @@
 const states = require("../config/states");
 
 class mdsHelper {
-  sourceParser(body) {
-    const data = JSON.parse(body.substring(13));
-    const brazil = data["brazil"][data["brazil"].length - 1];
-    const world = data["world"][data["world"].length - 1];
-    this.brazilValuesParser.call(brazil);
-    return {
-      brazil,
-      world,
-      updated_at: Date.now()
-    };
-  }
-  brazilValuesParser() {
-    this["values"] = this["values"].map(value => {
-      return {
-        uid: value["uid"] || "",
-        state: states[value["uid"]] || "",
-        cases: value["cases"] || 0,
-        deaths: value["deaths"] || 0,
-        suspects: value["suspects"] || 0,
-        refuses: value["refuses"] || 0,
-        broadcast: value["broadcast"] || false,
-        comments: value["comments"] || ""
-      };
-    });
-  }
+    sourceParser(body) {
+        const data = JSON.parse(body.substring(13));
+        const brazil = data["brazil"];
+        const world = data["world"][data["world"].length - 1];
+
+        return {
+            brazil: this.brazilValuesParser(brazil),
+            world,
+            updated_at: Date.now()
+        };
+    }
+    brazilValuesParser(brazilList) {
+        // Create a map with all states to take the history
+        const stateMap = new Map();
+        brazilList.forEach(item => {
+            item.values.forEach(itemValue => {
+                let history = stateMap.get(itemValue.uid);
+                if (!history) stateMap.set(itemValue.uid, (history = []));
+
+                history.push({
+                    date: item.date,
+                    ...this.informationValueParser(item)
+                });
+            });
+        });
+
+        // Get the last item from brazilList array, important to not break the current users
+        const lastBrazilItem = brazilList[brazilList.length - 1];
+
+        lastBrazilItem.values = lastBrazilItem.values.map(value => {
+            return {
+                uid: value.uid || "",
+                state: states[value.uid] || "",
+                ...this.informationValueParser(value),
+                history: stateMap.get(value.uid)
+            };
+        });
+
+        return lastBrazilItem;
+    }
+    informationValueParser(information) {
+        return {
+            cases: information.cases || 0,
+            deaths: information.deaths || 0,
+            suspects: information.suspects || 0,
+            refuses: information.refuses || 0,
+            broadcast: information.broadcast || false,
+            comments: information.comments || ""
+        };
+    }
 }
 
 module.exports = new mdsHelper();

--- a/src/helpers/mds.js
+++ b/src/helpers/mds.js
@@ -1,4 +1,5 @@
 const states = require("../config/states");
+const moment = require("moment");
 
 class mdsHelper {
     sourceParser(body) {
@@ -31,7 +32,10 @@ class mdsHelper {
                     date: item.date,
                     time: item.time,
                     date_iso: this.convertDateToISO8091(item.date, item.time),
-                    cases: itemValue.cases
+                    cases: itemValue.cases || 0,
+                    casesNew: itemValue.casesNew || 0,
+                    deaths: itemValue.deaths || 0,
+                    deathsNew: itemValue.deathsNew || 0
                 });
             });
         });
@@ -40,6 +44,7 @@ class mdsHelper {
         for (let worldUid of wordMap.keys()) {
             worldHistory.push({
                 uid: worldUid,
+                name: worldUid,
                 history: wordMap.get(worldUid) || []
             });
         }
@@ -83,7 +88,7 @@ class mdsHelper {
             values: []
         };
 
-        lastBrazilItem.values = lastBrazilItem.values.map(value => {
+        lastBrazilItem.values = values.map(value => {
             return {
                 uid: value.uid || "",
                 state: states[value.uid] || "",

--- a/src/helpers/mds.js
+++ b/src/helpers/mds.js
@@ -22,7 +22,7 @@ class mdsHelper {
 
                 history.push({
                     date: item.date,
-                    ...this.informationValueParser(item)
+                    ...this.informationValueParser(itemValue)
                 });
             });
         });

--- a/src/server.js
+++ b/src/server.js
@@ -1,3 +1,4 @@
 const app = require("./app");
+const PORT = process.env.PORT || 3000;
 
-app.listen(3000, console.log("Running on port 3000"));
+app.listen(PORT, console.log(`Running on port ${PORT}`));

--- a/yarn.lock
+++ b/yarn.lock
@@ -501,7 +501,7 @@ moment-timezone@^0.5.x:
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0":
+"moment@>= 2.9.0", moment@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==


### PR DESCRIPTION
I added a attribute called history (to not break current users) that show the history by date.

```diff
brazil": {
    "date": "16/03/2020",
    "time": "15:50",
    "values": [
      {
        "uid": 11,
        "state": "Rondônia (RO)",
        "cases": 0,
        "deaths": 0,
        "suspects": 2,
        "refuses": 1,
        "broadcast": false,
        "comments": "",
+      "history": [
          {
            "date": "02/03/2020",
            "state_uid": 11,
            "cases": 0,
            "deaths": 0,
            "suspects": 0,
            "refuses": 0,
            "broadcast": false,
            "comments": ""
          },
```

This is very good to use on history charts or to track how much increased per day